### PR TITLE
DJMTGuild rename and added discord Guild field

### DIFF
--- a/src/Component.ts
+++ b/src/Component.ts
@@ -1,5 +1,5 @@
 import {GuildMember, Message, MessageReaction, User, VoiceState} from "discord.js";
-import {Guild} from "./Guild";
+import {DJMTGuild} from "./DJMTGuild";
 import {ComponentNames} from "./Constants/ComponentNames";
 
 /**
@@ -18,10 +18,10 @@ import {ComponentNames} from "./Constants/ComponentNames";
  */
 export abstract class Component<T> {
     abstract name: ComponentNames;
-    guild: Guild;
+    djmtGuild: DJMTGuild;
 
-    public constructor(guild: Guild) {
-        this.guild = guild;
+    public constructor(guild: DJMTGuild) {
+        this.djmtGuild = guild;
     }
     // Events
     // (Not all events have been implemented, if you need one that isn't here, open a github issue for it.

--- a/src/Components/BruhComponent.ts
+++ b/src/Components/BruhComponent.ts
@@ -96,24 +96,22 @@ export class BruhComponent extends Component<BruhComponentSave> {
             for (const channelMentionStr of args) {
                 // Get the ID from the mention
                 let channelId = channelMentionStr.substring(2, channelMentionStr.indexOf('>'));
-                try {
-                    // Test if the channel exists before moving on
-                    const foundChannel = await this.guild.client.channels.fetch(channelId);
-                } catch (e) {
-                    console.error(e);
+                // Test if the channel exists before moving on
+                const foundChannel = this.djmtGuild.getGuildChannel(channelId);
+                if (!foundChannel) {
                     await message.channel.send("The given channel is invalid!");
                     continue;
                 }
                 // Remove the channel if it's already in the list
                 if (this.bruhChannels?.includes(channelId)) {
                     this.bruhChannels.splice(this.bruhChannels.indexOf(channelId), 1);
-                    await this.guild.saveJSON();
+                    await this.djmtGuild.saveJSON();
                     // await updateConfig(gConfig, message);
                     await message.channel.send(`Removed ${channelMentionStr} from the bruh channels list!`);
                 } else {
                     // Push the channelId to the bruhChannels list
                     this.bruhChannels.push(channelId);
-                    await this.guild.saveJSON();
+                    await this.djmtGuild.saveJSON();
                     await message.channel.send(`Added ${channelMentionStr} to the bruh channels list!`);
                 }
             }
@@ -190,7 +188,7 @@ export class BruhComponent extends Component<BruhComponentSave> {
                                 });
                             }
                             if (channelId) {
-                                const foundChannel = (await this.guild.client.channels.fetch(channelId) as TextChannel);
+                                const foundChannel = (this.djmtGuild.getGuildChannel(channelId) as TextChannel);
                                 searchMessage = await foundChannel.messages.fetch(messageId);
                                 msgContent = searchMessage.content;
                                 // TODO: if search message isnt found try again with another random message?

--- a/src/Components/ConfigComponent.ts
+++ b/src/Components/ConfigComponent.ts
@@ -68,8 +68,8 @@ export class ConfigComponent extends Component<ConfigComponentSave>{
             await message.channel.send(`This command requires administrator permissions.`);
             return;
         }
-        const jsonString = `${JSON.stringify({[this.guild.guildId]: this.guild.getSaveData()}, JSONStringifyReplacer, '  ')}`;
-        const attachment = new MessageAttachment(Buffer.from(jsonString), `config_${this.guild.guildId}_${DateTime.local().toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)}.txt`);
+        const jsonString = `${JSON.stringify({[this.djmtGuild.guildId]: this.djmtGuild.getSaveData()}, JSONStringifyReplacer, '  ')}`;
+        const attachment = new MessageAttachment(Buffer.from(jsonString), `config_${this.djmtGuild.guildId}_${DateTime.local().toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS)}.txt`);
         await message.channel.send(attachment);
     }
 
@@ -79,7 +79,7 @@ export class ConfigComponent extends Component<ConfigComponentSave>{
             await message.channel.send(`This command requires administrator permissions.`);
             return;
         }
-        await this.guild.resetJSON();
+        await this.djmtGuild.resetJSON();
         await message.channel.send(`Reset my guild config to default settings.`);
     }
 

--- a/src/Components/GuildSettersComponent.ts
+++ b/src/Components/GuildSettersComponent.ts
@@ -68,9 +68,9 @@ export class GuildSettersComponent extends Component<DebugComponentSave> {
             await message.channel.send(`This command requires administrator permissions.`);
             return;
         }
-        this.guild.debugMode = !this.guild.debugMode;
+        this.djmtGuild.debugMode = !this.djmtGuild.debugMode;
         // await updateConfig(gConfig, message);
-        await message.channel.send(`Dev Mode ${this.guild.debugMode ? "enabled" : "disabled" }.`);
+        await message.channel.send(`Dev Mode ${this.djmtGuild.debugMode ? "enabled" : "disabled" }.`);
     }
 
     async setDebugChannel(args: string[], message: Message) {
@@ -79,11 +79,11 @@ export class GuildSettersComponent extends Component<DebugComponentSave> {
             await message.channel.send(`This command requires administrator permissions.`);
             return;
         }
-        if (this.guild.debugChannelId === message.channel.id) {
-            this.guild.debugChannelId = "";
+        if (this.djmtGuild.debugChannelId === message.channel.id) {
+            this.djmtGuild.debugChannelId = "";
             await message.channel.send(`${message.channel.toString()} is no longer set as the debugChannel`);
         } else {
-            this.guild.debugChannelId = message.channel.id;
+            this.djmtGuild.debugChannelId = message.channel.id;
             await message.channel.send(`${message.channel.toString()} is now set as the debugChannel channel`);
         }
     }
@@ -95,11 +95,11 @@ export class GuildSettersComponent extends Component<DebugComponentSave> {
             return;
         }
         if (args.length === 0) {
-            this.guild.prefix = process.env.DEFAULT_PREFIX as string;
+            this.djmtGuild.prefix = process.env.DEFAULT_PREFIX as string;
             await message.channel.send(`Set my prefix to \`\`${process.env.DEFAULT_PREFIX}\`\``);
         } else if (args.length === 1) {
-            this.guild.prefix = args[0] ? args[0] : process.env.DEFAULT_PREFIX as string;
-            await message.channel.send(`Set my prefix to \`\`${this.guild.prefix}\`\``);
+            this.djmtGuild.prefix = args[0] ? args[0] : process.env.DEFAULT_PREFIX as string;
+            await message.channel.send(`Set my prefix to \`\`${this.djmtGuild.prefix}\`\``);
         } else {
             await message.channel.send(`Please enter a single prefix.`);
         }

--- a/src/Components/HelpComponent.ts
+++ b/src/Components/HelpComponent.ts
@@ -53,7 +53,7 @@ export class HelpComponent extends Component<HelpComponentSave> {
     }
 
     async helpCmd(args: string[], message: Message) {
-        let prefix = this.guild.prefix;
+        let prefix = this.djmtGuild.prefix;
         let helpCommands =
             `#FUN
 ${prefix}cheems [text] -> Cheemsifies the given text.\n

--- a/src/Components/PNGResolutionCheck.ts
+++ b/src/Components/PNGResolutionCheck.ts
@@ -63,8 +63,13 @@ export class PNGResolutionCheck extends Component<PNGResolutionCheckSave> {
             for (const key of Array.from(loadedObject.channels.keys())) {
                 const value = loadedObject.channels.get(key);
                 if (value) {
+                    const channel = this.djmtGuild.getGuildChannel(value.channel) as TextChannel;
+                    if (!channel) {
+                        console.error(`[PNGResolutionCheck]: could not load ${value}`);
+                        continue;
+                    }
                     const newValue: PNGResolutionEntry = {
-                        channel: await this.guild.client.channels.fetch(value.channel) as TextChannel,
+                        channel: channel,
                         height: value.height,
                         width: value.width
                     }
@@ -241,7 +246,7 @@ export class PNGResolutionCheck extends Component<PNGResolutionCheckSave> {
             width: entry.width,
             height: entry.height
         });
-        await this.guild.saveJSON();
+        await this.djmtGuild.saveJSON();
         return `Added ${entry.channel.toString()} to PNG Resolution Checking Channels!`;
     }
 
@@ -252,7 +257,7 @@ export class PNGResolutionCheck extends Component<PNGResolutionCheckSave> {
     async removePNGRCChannel(channel: TextChannel) {
         if (this.channelsMap.get(channel.id)) {
             this.channelsMap.delete(channel.id);
-            await this.guild.saveJSON();
+            await this.djmtGuild.saveJSON();
             return `Removed ${channel.toString()} from PNG Resolution Checking Channels`;
         } else {
             return `${channel.toString()} is not a PNG Resolution Checking Channel`;

--- a/src/Components/PingComponent.ts
+++ b/src/Components/PingComponent.ts
@@ -55,7 +55,7 @@ export class PingComponent extends Component<PingComponentSave>{
         // Calculates ping between sending a message and editing it, giving a nice round-trip latency.
         // The second ping is an average latency between the bot and the websocket server (one-way, not round-trip)
         const m = await message.channel.send("Ping?");
-        await m.edit(`Pong! Latency is ${m.createdTimestamp - message.createdTimestamp}ms. API Latency is ${Math.round(this.guild.client.ws.ping)}ms`);
+        await m.edit(`Pong! Latency is ${m.createdTimestamp - message.createdTimestamp}ms. API Latency is ${Math.round(this.djmtGuild.guild?.client.ws.ping ?? -1)}ms`);
     }
 
 }

--- a/src/Components/ReactBoardsComponent.ts
+++ b/src/Components/ReactBoardsComponent.ts
@@ -124,16 +124,14 @@ export class ReactBoardsComponent extends Component<ReactBoardSave> {
             let emoteId = rawEmote.substring(rawEmote.lastIndexOf(':') + 1, rawEmote.indexOf('>'));
             let foundEmote = undefined;
             // let foundTextChannel = undefined;
-            foundEmote = this.guild.client.emojis.cache.get(emoteId);
+            foundEmote = this.djmtGuild.guild?.emojis.cache.get(emoteId);
             if (!foundEmote) {
                 await message.channel.send(`The given emote is invalid, is it in this server?`);
                 return;
             }
             let channelId = rawChannelId.substring(2, rawChannelId.indexOf('>'));
-            try {
-                const foundChannel = await this.guild.client.channels.fetch(channelId);
-            } catch (e) {
-                console.error(e);
+            const foundChannel = this.djmtGuild.getGuildChannel(channelId);
+            if (!foundChannel) {
                 await message.channel.send("The given channel is invalid!");
                 return;
             }
@@ -146,16 +144,16 @@ export class ReactBoardsComponent extends Component<ReactBoardSave> {
                     if (this.autoReactMap.get(rawEmote).length < 1) {
                         this.autoReactMap.delete(rawEmote)
                     }
-                    await this.guild.saveJSON();
+                    await this.djmtGuild.saveJSON();
                     await message.channel.send(`Removed ${rawChannelId} from the auto react list for ${rawEmote}`);
                 } else {
                     this.autoReactMap.get(rawEmote)?.push(channelId);
-                    await this.guild.saveJSON();
+                    await this.djmtGuild.saveJSON();
                     await message.channel.send(`Added ${rawChannelId} to the auto react list for ${rawEmote}!`);
                 }
             } else {
                 this.autoReactMap.set(rawEmote, [channelId]);
-                await this.guild.saveJSON();
+                await this.djmtGuild.saveJSON();
                 await message.channel.send(`Added ${rawChannelId} to the auto react list for ${rawEmote}!`);
             }
         } else {
@@ -176,7 +174,7 @@ export class ReactBoardsComponent extends Component<ReactBoardSave> {
                 let msg = '';
                 this.emoteReactBoardMap.forEach((value, key) => {
                     const emoteId = key.substring(key.lastIndexOf(':') + 1, key.indexOf('>'));
-                    const emoji = this.guild.client.emojis.cache.get(emoteId);
+                    const emoji = this.djmtGuild.guild?.emojis.cache.get(emoteId);
                     msg += `${emoji?.toString()} => <#${value.channelId}> (threshold: ${value.threshold})\n`;
                 });
                 await message.channel.send(`React Channels:\n${msg}`);
@@ -196,18 +194,14 @@ export class ReactBoardsComponent extends Component<ReactBoardSave> {
             }
             let emoteId = rawEmote.substring(rawEmote.lastIndexOf(':') + 1, rawEmote.indexOf('>'));
             let channelId = rawChannelId.substring(2, rawChannelId.indexOf('>'));
-            let foundEmote = undefined;
-            let foundTextChannel = undefined;
-            try {
-                foundEmote = this.guild.client.emojis.cache.get(emoteId);
-                foundTextChannel = await this.guild.client.channels.fetch(channelId);
-            } catch (e) {
-                console.error(e);
-                await message.channel.send("The given channel or emote is invalid! Make sure the given channels are the correct types (use help command for more info)");
+            let foundEmote = this.djmtGuild.guild?.emojis.cache.get(emoteId);
+            let foundTextChannel = this.djmtGuild.getGuildChannel(channelId);
+            if (!foundEmote || !foundTextChannel) {
+                await message.channel.send("The given channel or emote is invalid!");
                 return;
             }
-            if (foundEmote && foundTextChannel.type !== "text") {
-                await message.channel.send(`The given args are invalid`);
+            if (foundTextChannel.type !== "text") {
+                await message.channel.send(`The given channel is not a Text Channel`);
                 return;
             }
             if (this.emoteReactBoardMap.has(rawEmote) &&
@@ -217,7 +211,7 @@ export class ReactBoardsComponent extends Component<ReactBoardSave> {
                 // If we have a match delete it from the map and the config
                 this.emoteReactBoardMap.delete(rawEmote);
 
-                await this.guild.saveJSON();
+                await this.djmtGuild.saveJSON();
                 await message.channel.send(`Removed [${rawEmote}, ${val.channelId}, ${val.threshold}] from React Channels list!`);
                 return;
 
@@ -230,7 +224,7 @@ export class ReactBoardsComponent extends Component<ReactBoardSave> {
                     recentMsgIds: [],
                 }
                 this.emoteReactBoardMap.set(rawEmote, reactBoardMapValue);
-                await this.guild.saveJSON();
+                await this.djmtGuild.saveJSON();
                 await message.channel.send(`Added ${rawEmote} => <#${channelId}> to the React Channels list (threshold ${threshold})!`);
             }
 
@@ -244,7 +238,7 @@ export class ReactBoardsComponent extends Component<ReactBoardSave> {
         let channelId = message.channel.id;
         this.autoReactMap.forEach((channelIds, rawEmojiId) => {
             const emoteId = rawEmojiId.substring(rawEmojiId.lastIndexOf(':') + 1, rawEmojiId.indexOf('>'));
-            const foundEmote = this.guild.client.emojis.cache.get(emoteId);
+            const foundEmote = this.djmtGuild.guild?.emojis.cache.get(emoteId);
             channelIds.forEach(async mapChannelId => { // TODO: async might be weird here
                 if (foundEmote && channelId === mapChannelId) {
                     await message.react(foundEmote);
@@ -261,7 +255,7 @@ export class ReactBoardsComponent extends Component<ReactBoardSave> {
             const reactMapValue = this.emoteReactBoardMap.get(rawEmoteId);
             if (reaction.count === reactMapValue?.threshold && reactMapValue?.channelId) {
                 const message = reaction.message;
-                const channel = (await this.guild.client.channels.fetch(reactMapValue.channelId) as TextChannel);
+                const destinationChannel = this.djmtGuild.getGuildChannel(reactMapValue.channelId) as TextChannel;
                 const embed = new MessageEmbed();
                 embed.type = 'rich';
                 embed.setDescription(`[Original Message](${message.url})`)
@@ -274,7 +268,7 @@ export class ReactBoardsComponent extends Component<ReactBoardSave> {
                 .setImage(message.attachments.array().length > 0 ? message.attachments.array()[0].url : '')
                 .setAuthor(`${message.author.username}#${message.author.discriminator} (${message.author.id})`, message.author.displayAvatarURL({size: 128, dynamic: true}))
                 .setFooter(`${reaction.count} ⭐ | ${message.id}`);
-                await channel.send({embed: embed});
+                await destinationChannel.send({embed: embed});
                 this.emoteReactBoardMap?.get(rawEmoteId)?.recentMsgIds?.push(message.id);
                 // We dont care about recent msg ids being saved to file, so dont save here.
             }
@@ -300,23 +294,21 @@ export class ReactBoardsComponent extends Component<ReactBoardSave> {
         } else {
             for (const rawChannelId of args) {
                 let channelId = rawChannelId.substring(2, rawChannelId.indexOf('>'));
-                try {
-                    const foundChannel = await this.guild.client.channels.fetch(channelId);
-                } catch (e) {
-                    console.error(e);
+                const foundChannel = await this.djmtGuild.getGuildChannel(channelId);
+                if (!foundChannel) {
                     await message.channel.send("The given channel is invalid!");
                     continue;
                 }
                 if (this.starChannels?.includes(channelId)) {
                     this.starChannels.splice(this.starChannels.indexOf(channelId), 1);
-                    await this.guild.saveJSON();
+                    await this.djmtGuild.saveJSON();
                     await message.channel.send(`Removed ${rawChannelId} from the star channels list!`);
                 } else {
                     if (!this.starChannels) {
                         this.starChannels = [];
                     }
                     this.starChannels.push(channelId);
-                    await this.guild.saveJSON();
+                    await this.djmtGuild.saveJSON();
                     await message.channel.send(`Added ${rawChannelId} to the star channels list!`);
                 }
             }

--- a/src/Components/VCHoursComponent.ts
+++ b/src/Components/VCHoursComponent.ts
@@ -33,7 +33,7 @@ export class VCHoursComponent extends Component<VCHoursComponentSave> {
     }
 
     async onReady(): Promise<void> {
-        const vcChannelPairs: VoiceTextPair[] = (this.guild.getComponent(ComponentNames.VOICE_TEXT_PAIR) as VoiceTextPairComponent).voiceTextPairs;
+        const vcChannelPairs: VoiceTextPair[] = (this.djmtGuild.getComponent(ComponentNames.VOICE_TEXT_PAIR) as VoiceTextPairComponent).voiceTextPairs;
         for (const pair of vcChannelPairs) {
             this.consecutiveHours.set(pair, 0);
         }
@@ -86,7 +86,7 @@ export class VCHoursComponent extends Component<VCHoursComponentSave> {
             let voiceId = args[0];
             let textId = args[1];
             let hours = Number(args[2]);
-            const vcChannelPairs: VoiceTextPair[] = (this.guild.getComponent(ComponentNames.VOICE_TEXT_PAIR) as VoiceTextPairComponent).voiceTextPairs;
+            const vcChannelPairs: VoiceTextPair[] = (this.djmtGuild.getComponent(ComponentNames.VOICE_TEXT_PAIR) as VoiceTextPairComponent).voiceTextPairs;
             for (const pair of vcChannelPairs) {
                 if (pair.voiceChannel.id === voiceId && pair.textChannel.id === textId) {
                     this.consecutiveHours.set(pair, hours);
@@ -101,12 +101,16 @@ export class VCHoursComponent extends Component<VCHoursComponentSave> {
     }
 
     async vcRemindersJob() {
-        console.log(`[${this.guild.guildId}] Running VC Reminder Job`);
-        const vcChannelPairs: VoiceTextPair[] = (this.guild.getComponent(ComponentNames.VOICE_TEXT_PAIR) as VoiceTextPairComponent).voiceTextPairs;
+        console.log(`[${this.djmtGuild.guildId}] Running VC Reminder Job`);
+        const vcChannelPairs: VoiceTextPair[] = (this.djmtGuild.getComponent(ComponentNames.VOICE_TEXT_PAIR) as VoiceTextPairComponent).voiceTextPairs;
         // For each channel pair
         for (const pair of vcChannelPairs) {
-            const voiceChannel = (await this.guild.client.channels.fetch(pair.voiceChannel.id) as VoiceChannel);
-            const textChannel = (await this.guild.client.channels.fetch(pair.textChannel.id) as TextChannel);
+            const voiceChannel = (this.djmtGuild.getGuildChannel(pair.voiceChannel.id) as VoiceChannel);
+            const textChannel = (this.djmtGuild.getGuildChannel(pair.textChannel.id) as TextChannel);
+            if (!voiceChannel || !textChannel) {
+                console.error(`[VCRemindersJob] Could not find voice channel ${pair.voiceChannel.id} or text channel ${pair.textChannel.id}`)
+                return;
+            }
             // If someone is in the channel during the check and they are not a bot, add an hour
             if (voiceChannel.members.size > 0 && !voiceChannel.members.every(member => member.user.bot)) {
                 const hoursSoFar = this.consecutiveHours.get(pair) ?? 0;

--- a/src/Components/VoiceTextPairComponent.ts
+++ b/src/Components/VoiceTextPairComponent.ts
@@ -81,12 +81,12 @@ export class VoiceTextPairComponent extends Component<VoiceTextPairComponentSave
         for (const pair of this.voiceTextPairs) {
             if (pair.voiceChannel.id === voiceChannel.id && pair.textChannel.id === textChannel.id) {
                 this.voiceTextPairs.splice(this.voiceTextPairs.indexOf(pair),  1);
-                await this.guild.saveJSON();
+                await this.djmtGuild.saveJSON();
                 return false;
             }
         }
         this.voiceTextPairs.push(pair);
-        await this.guild.saveJSON();
+        await this.djmtGuild.saveJSON();
         return true;
     }
 
@@ -111,13 +111,9 @@ export class VoiceTextPairComponent extends Component<VoiceTextPairComponentSave
             const voiceChannelId = args[0]; // Voice channel must be raw due to lack of mention
             const rawTextChannelId = args[1];
             let textChannelId = rawTextChannelId.substring(2, rawTextChannelId.indexOf('>'));
-            let foundVoiceChannel = undefined;
-            let foundTextChannel = undefined;
-            try {
-                foundVoiceChannel = await this.guild.client.channels.fetch(voiceChannelId);
-                foundTextChannel = await this.guild.client.channels.fetch(textChannelId);
-            } catch (e) {
-                console.error(e);
+            let foundVoiceChannel = this.djmtGuild.getGuildChannel(voiceChannelId);
+            let foundTextChannel = this.djmtGuild.getGuildChannel(textChannelId);
+            if (!foundTextChannel || !foundVoiceChannel) {
                 await message.channel.send("The given channel is invalid! Make sure the given channels are the correct types (use help command for more info)");
                 return;
             }

--- a/src/DJMTbot.ts
+++ b/src/DJMTbot.ts
@@ -6,7 +6,7 @@ import Discord, {
     VoiceState
 } from "discord.js";
 import {promises as FileSystem} from "fs";
-import {Guild} from "./Guild";
+import {DJMTGuild} from "./DJMTGuild";
 import {Cron} from "./Cron";
 // Here we load the guildConfigs.json file that contains our token and our prefix values.
 require('dotenv').config();
@@ -15,11 +15,11 @@ Cron.getInstance();
 export class DJMTbot {
     private static instance: DJMTbot;
     client: Client;
-    guilds: Map<string, Guild>;
+    guilds: Map<string, DJMTGuild>;
     private constructor() {
         this.client = new Discord.Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
-        this.guilds = new Map<string, Guild>();
-        this.initGuildInstancesFromFiles().then(r => console.log('Guilds Initialized'));
+        this.guilds = new Map<string, DJMTGuild>();
+        this.initGuildInstancesFromFiles().then(r => console.log(`${this.guilds.size} DJMT Guilds Initialized`));
     }
 
     public static async getInstance(): Promise<DJMTbot> {
@@ -33,7 +33,7 @@ export class DJMTbot {
         const files = await FileSystem.readdir('./json/guilds');
         const guildIds = files.map((filename) => filename.substr(0, filename.indexOf('.')));
         for (const id of guildIds) {
-            const guild = new Guild(this.client, id);
+            const guild = new DJMTGuild(id);
             this.guilds.set(id, guild);
         }
     }
@@ -44,7 +44,7 @@ export class DJMTbot {
             for (let cachedGuild of this.client.guilds.cache.array()) {
                 const guildId = cachedGuild.id;
                 if (!this.guilds.get(guildId)) {
-                    const guild = new Guild(this.client, guildId);
+                    const guild = new DJMTGuild(guildId);
                     this.guilds.set(guildId, guild);
                 }
             }
@@ -52,7 +52,7 @@ export class DJMTbot {
             for (const id of Array.from(this.guilds.keys())) {
                 await this.guilds.get(id)?.onReady();
             }
-            console.log(`Bot is ready!`);
+            console.log(`DJMTbot is ready!`);
         });
 
         this.client.on('guildMemberAdd', async (member) => {
@@ -139,6 +139,6 @@ export class DJMTbot {
             console.log(`I have been removed from: ${guild.name} (id: ${guild.id})`);
         });
 
-        await this.client.login(process.env.TOKEN);
+        await this.client.login(process.env.DEV_TOKEN);
     }
 }


### PR DESCRIPTION
Guilds renamed to DJMTGuild to avoid conflict with discord Guild class. 
DJMTGuilds no longer have a client field.
DJMTGuilds now have a discord Guild field that is fetched during the onReady event. If it isn't fetched, the DJMTGuild fails to be ready. 
DJMTGuilds now have a getGuildChannel function to get channels in a limited scope to the channel it is in.
Closes #23 