### PR TITLE
Increase the user limit for additional VCs

### DIFF
--- a/src/Components/DynamicVoiceChannels.ts
+++ b/src/Components/DynamicVoiceChannels.ts
@@ -47,7 +47,7 @@ export class DynamicVoiceChannels extends Component<DynamicVoiceChannelsSave> {
     name: ComponentNames = ComponentNames.DYNAMIC_VOICE_CHANNELS;
     markedVoiceChannels: DynamicVoiceChannel[] = [];
     private readonly GUILD_MAXIMUM_GENERATED_CHANNELS = 7;
-    private readonly MINIMUM_NUMBER_OF_OCCUPANTS = 4;
+    private readonly MINIMUM_NUMBER_OF_OCCUPANTS = 7;
     creatingChannel: Map<string, boolean> = new Map();
 
     async getSaveData(): Promise<DynamicVoiceChannelsSave> {


### PR DESCRIPTION
Increase the user limit for additional VCs (like Gaming 2, Gaming 3 and so on) to at least 7 users instead of the previous 4. In the past especially Gaming 2 was full quite often with 7 users and no one was able to join there to watch streams.